### PR TITLE
Add cache hit and request response time metric support using sentry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 env
 _*_cache
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 RUN pip install -r requirements.txt
 
 ENV OVERPASS_URL=https://overpass.kumi.systems/api/interpreter/
-
+# Leave these variables undefined; to use sentry, provide them in a .env file with docker compose or on the command line.
+ENV SENTRY_DSN
+ENV SENTRY_TSR
 EXPOSE 8080
-CMD python main.py --overpass-url $OVERPASS_URL
+CMD python main.py --overpass-url $OVERPASS_URL --sentry-dsn $SENTRY_DSN --sentry-tsr $SENTRY_TSR

--- a/app/cache.py
+++ b/app/cache.py
@@ -43,12 +43,12 @@ class CompressedJSONCache:
         path = self.dir.joinpath(f"{key}.json.gz")
         # Record whether this is a cache hit or not
         if self._should_fetch(path):
-            set_tag("cache_hit", True)
+            set_tag("cache_hit", False)
             self.evict_if_needed()
             with gzip.open(path, "wt", encoding="ascii") as f:
                 json.dump(await fetch_func(), f)
         else:
-            set_tag("cache_hit", False)
+            set_tag("cache_hit", True)
 
         with gzip.open(path, "rb") as f:
             return json.load(f)

--- a/app/main.py
+++ b/app/main.py
@@ -36,9 +36,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--port", type=int, help="TCP Port to listen on", default=8080)
     parser.add_argument(
-        "--sentry-url",
+        "--sentry-dsn",
         type=str,
-        help="""The sentry URL to pass to the SDK. If none is provided, sentry is not used.""",
+        help="""The sentry data source name URL to pass to the SDK. If none is provided, sentry is not used.""",
     )
     parser.add_argument(
         "--sentry-tsr",
@@ -55,6 +55,6 @@ if __name__ == "__main__":
         args.cache_days,
         args.cache_size,
         args.port,
-        args.sentry_url,
-        sentry_tsr,
+        args.sentry_dsn,
+        args.sentry_tsr,
     )

--- a/app/main.py
+++ b/app/main.py
@@ -34,11 +34,17 @@ if __name__ == "__main__":
         help="Maximum number of JSON responses to store",
         default=1e5,
     )
+    parser.add_argument("--port", type=int, help="TCP Port to listen on", default=8080)
     parser.add_argument(
-        "--port",
-        type=int,
-        help="TCP Port to listen on",
-        default=8080
+        "--sentry-url",
+        type=str,
+        help="""The sentry URL to pass to the SDK. If none is provided, sentry is not used.""",
+    )
+    parser.add_argument(
+        "--sentry-tsr",
+        type=float,
+        help="""The trace sample rate value for overscape in sentry, a number from 0.0 to 1.0, which sets the approximate percent of app queries will have traces recorded for sampling.""",
+        default=0.1,
     )
     args = parser.parse_args()
 
@@ -48,5 +54,7 @@ if __name__ == "__main__":
         args.cache_dir,
         args.cache_days,
         args.cache_size,
-        args.port
+        args.port,
+        args.sentry_url,
+        sentry_tsr,
     )

--- a/app/overpass.py
+++ b/app/overpass.py
@@ -60,13 +60,11 @@ class OverpassClient:
 
     @sentry_sdk.trace
     async def _execute_query(self, q):
-        if(not self.session):
-           self.session = aiohttp.ClientSession()
+        if not self.session:
+            self.session = aiohttp.ClientSession()
         try:
             async with self.session.get(
-                self.server,
-                params={"data": q},
-                headers={"User-Agent": self.user_agent}
+                self.server, params={"data": q}, headers={"User-Agent": self.user_agent}
             ) as response:
                 if response.status != 200:
                     logger.warning(f"received {response.status} from {self.server}")
@@ -75,8 +73,8 @@ class OverpassClient:
                 return OverpassResponse(json)
         except Exception as e:
             logger.warning("got exception", exc_info=True)
+            sentry_sdk.capture_exception(e)
             return None
-            
 
     @sentry_sdk.trace
     async def query(self, x, y):

--- a/app/overpass.py
+++ b/app/overpass.py
@@ -2,6 +2,7 @@ import json
 import logging
 import math
 from pathlib import Path
+import sentry_sdk
 
 import osm2geojson
 from shapely.geometry import mapping, Point
@@ -57,6 +58,7 @@ class OverpassClient:
         );
         out geom;"""
 
+    @sentry_sdk.trace
     async def _execute_query(self, q):
         if(not self.session):
            self.session = aiohttp.ClientSession()
@@ -76,9 +78,11 @@ class OverpassClient:
             return None
             
 
+    @sentry_sdk.trace
     async def query(self, x, y):
         return await self.cache.get(f"{x}_{y}", lambda: self.uncached_query(x, y))
 
+    @sentry_sdk.trace
     async def uncached_query(self, x, y):
         q = self._build_query(x, y)
         overpass_response = await self._execute_query(q)

--- a/app/server.py
+++ b/app/server.py
@@ -3,6 +3,7 @@ import json
 from aiohttp import web
 from overpass import ZOOM_DEFAULT, OverpassClient
 import sentry_sdk
+from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 
 # based on https://github.com/microsoft/soundscape/blob/main/svcs/data/gentiles.py
@@ -27,8 +28,23 @@ async def tile_handler(request):
         return web.Response(text=tile_data, content_type="application/json")
 
 
-def run_server(overpass_url, user_agent, cache_dir, cache_days, cache_size, port, sentry_dsn, sentry_tsr):
-    sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_tsr)
+def run_server(
+    overpass_url,
+    user_agent,
+    cache_dir,
+    cache_days,
+    cache_size,
+    port,
+    sentry_dsn,
+    sentry_tsr,
+):
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        traces_sample_rate=sentry_tsr,
+        integrations=[
+            AioHttpIntegration(),
+        ],
+    )
     app = web.Application()
     app["overpass_client"] = OverpassClient(
         overpass_url, user_agent, cache_dir, cache_days, cache_size

--- a/app/server.py
+++ b/app/server.py
@@ -2,6 +2,7 @@
 import json
 from aiohttp import web
 from overpass import ZOOM_DEFAULT, OverpassClient
+import sentry_sdk
 
 
 # based on https://github.com/microsoft/soundscape/blob/main/svcs/data/gentiles.py
@@ -26,7 +27,8 @@ async def tile_handler(request):
         return web.Response(text=tile_data, content_type="application/json")
 
 
-def run_server(overpass_url, user_agent, cache_dir, cache_days, cache_size, port):
+def run_server(overpass_url, user_agent, cache_dir, cache_days, cache_size, port, sentry_url, sentry_tsr):
+    sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_tsr)
     app = web.Application()
     app["overpass_client"] = OverpassClient(
         overpass_url, user_agent, cache_dir, cache_days, cache_size

--- a/app/server.py
+++ b/app/server.py
@@ -7,6 +7,7 @@ from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 
 
 # based on https://github.com/microsoft/soundscape/blob/main/svcs/data/gentiles.py
+@sentry_sdk.trace
 async def gentile_async(zoom, x, y, overpass_client):
     response = await overpass_client.query(x, y)
     if response is None:
@@ -15,6 +16,7 @@ async def gentile_async(zoom, x, y, overpass_client):
 
 
 # based on https://github.com/microsoft/soundscape/blob/main/svcs/data/gentiles.py
+@sentry_sdk.trace
 async def tile_handler(request):
     zoom = request.match_info["zoom"]
     if int(zoom) != ZOOM_DEFAULT:

--- a/app/server.py
+++ b/app/server.py
@@ -27,7 +27,7 @@ async def tile_handler(request):
         return web.Response(text=tile_data, content_type="application/json")
 
 
-def run_server(overpass_url, user_agent, cache_dir, cache_days, cache_size, port, sentry_url, sentry_tsr):
+def run_server(overpass_url, user_agent, cache_dir, cache_days, cache_size, port, sentry_dsn, sentry_tsr):
     sentry_sdk.init(dsn=sentry_url, traces_sample_rate=sentry_tsr)
     app = web.Application()
     app["overpass_client"] = OverpassClient(

--- a/app/server.py
+++ b/app/server.py
@@ -47,6 +47,9 @@ def run_server(
             AioHttpIntegration(),
         ],
     )
+    sentry_sdk.set_tag(
+        "overpass_url", overpass_url
+    )  # Tag all requests for the lifecycle of the app with the overpass URL used
     app = web.Application()
     app["overpass_client"] = OverpassClient(
         overpass_url, user_agent, cache_dir, cache_days, cache_size

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,8 @@ services:
       dockerfile: Dockerfile
     environment:
       - OVERPASS_URL=http://overpass/api/interpreter
+      - SENTRY_DSN=$SENTRY_DSN
+      - SENTRY_TSR=$SENTRY_TSR
     ports:
       - "8080:8080"
     depends_on:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp==3.8.4
 osm2geojson==0.2.3
 shapely==2.0.1
+sentry-sdk==1.25.1


### PR DESCRIPTION
This PR adds support for [sentry](https://sentry.io), an open source and self-hostable application performance monitoring and error tracking system. It uses sentry's aiohttp integration to measure information from requests at a configurable sampling rate, and also tags requests with a cache_hit tag, set to true when the tile is served from the cache and false when its retrieved from the overpass server.  
The [Sentry data source name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/) and sampling rate are command line arguments, and the Dockerfile and docker-compose.yml should be updated to pull those two environment variables, 'SENTRY_DSN' and 'SENTRY_TSR' from a .env file, or from your shell if set when you run docker compose up.
If only a dsn is given, the default sampling rate of 0.1, or ~10% of requests will be sent as events to the sentry server.  
With no .env file, no sentry server is in use.